### PR TITLE
Refine storyline cards and highlight officer team

### DIFF
--- a/about.html
+++ b/about.html
@@ -51,6 +51,21 @@
             </p>
           </div>
         </div>
+        <div class="wrapper">
+          <div class="officer-details" data-animate>
+            <p class="officer-heading">Officer Team</p>
+            <dl class="officer-list">
+              <div class="officer-list-item">
+                <dt>President in Charge</dt>
+                <dd>Aryan Sharma</dd>
+              </div>
+              <div class="officer-list-item">
+                <dt>Treasurer</dt>
+                <dd>Pratham Patil</dd>
+              </div>
+            </dl>
+          </div>
+        </div>
       </section>
 
       <section class="section" aria-labelledby="team-structure">
@@ -172,7 +187,7 @@
                 </div>
                 <div class="team-card-body">
                   <p class="team-role">President in Charge</p>
-                  <p class="team-name">Jordan Ellis</p>
+                  <p class="team-name">Aryan Sharma</p>
                 </div>
               </article>
               <article class="team-card">
@@ -181,7 +196,7 @@
                 </div>
                 <div class="team-card-body">
                   <p class="team-role">Treasurer</p>
-                  <p class="team-name">Morgan Patel</p>
+                  <p class="team-name">Pratham Patil</p>
                 </div>
               </article>
             </div>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -269,33 +269,36 @@ nav.primary-nav a.active::after {
 }
 
 .story-card {
-  padding: 2rem;
+  padding: 2.25rem 2rem 2.25rem 3rem;
   border-radius: 0.75rem;
   border: 1px solid var(--card-border);
   background: linear-gradient(160deg, rgba(56, 189, 248, 0.06), rgba(15, 23, 42, 0.8));
   box-shadow: var(--shadow-soft);
   position: relative;
   isolation: isolate;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: flex-start;
 }
 
 .story-card::before {
   content: attr(data-step);
-  position: absolute;
-  top: 1.5rem;
-  right: 1.5rem;
+  display: block;
   font-size: 0.85rem;
-  letter-spacing: 0.15em;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--accent);
+  margin-left: -2.5rem;
 }
 
 .story-card h3 {
-  margin-top: 0;
+  margin: 0;
   font-size: 1.3rem;
 }
 
 .story-card p {
-  margin-bottom: 0;
+  margin: 0;
   color: var(--text-muted);
 }
 
@@ -569,6 +572,50 @@ footer.site-footer {
   font-size: 0.85rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+}
+
+.officer-details {
+  margin-top: 3rem;
+  padding-top: 2.5rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.25);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.officer-heading {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.officer-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  margin: 0;
+  padding: 0;
+}
+
+.officer-list-item {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.officer-list-item dt {
+  font-size: 0.8rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.officer-list-item dd {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: var(--text-primary);
 }
 
 .resources-grid {


### PR DESCRIPTION
## Summary
- left-align the chapter numbering on storyline cards and add breathing room before the titles for a cleaner narrative layout
- add a styled officer details block to the About Us hero that calls out the President in Charge and Treasurer
- update the leadership section to reflect Aryan Sharma and Pratham Patil as the current officers

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68cf7bb330d08324852fe1fce452ba11