### PR TITLE
Refine storyline chapter card alignment

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -264,12 +264,13 @@ nav.primary-nav a.active::after {
 
 .storyline-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 2.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 2rem;
+  justify-items: start;
 }
 
 .story-card {
-  padding: 2.25rem 2rem 2.25rem 3rem;
+  padding: 1.75rem 1.75rem 1.85rem;
   border-radius: 0.75rem;
   border: 1px solid var(--card-border);
   background: linear-gradient(160deg, rgba(56, 189, 248, 0.06), rgba(15, 23, 42, 0.8));
@@ -278,18 +279,18 @@ nav.primary-nav a.active::after {
   isolation: isolate;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.65rem;
   align-items: flex-start;
+  width: min(100%, 320px);
 }
 
 .story-card::before {
   content: attr(data-step);
   display: block;
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--accent);
-  margin-left: -2.5rem;
 }
 
 .story-card h3 {


### PR DESCRIPTION
## Summary
- align storyline chapter numbers, titles, and descriptions to a shared left margin
- tighten spacing and padding so the chapter cards feel compact
- constrain the card width inside the grid for a cleaner presentation

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cf80a60d6c8324a65708b996a64ad6