### PR TITLE
Add vice president and refresh About page leadership layout

### DIFF
--- a/about.html
+++ b/about.html
@@ -63,6 +63,10 @@
                 <dt>Treasurer</dt>
                 <dd>Pratham Patil</dd>
               </div>
+              <div class="officer-list-item">
+                <dt>Vice President</dt>
+                <dd>Will Greenwood</dd>
+              </div>
             </dl>
           </div>
         </div>
@@ -181,22 +185,32 @@
           <div class="team-group" data-animate>
             <h3 class="team-group-title">Leadership</h3>
             <div class="team-grid team-grid-leadership">
-              <article class="team-card">
+              <!-- Leadership cards use an overlay treatment to create the required fade without introducing a new component. -->
+              <article class="team-card team-card-leader" tabindex="0">
                 <div class="team-image">
-                  <img src="member_pictures/president.svg" alt="President in Charge" />
-                </div>
-                <div class="team-card-body">
-                  <p class="team-role">President in Charge</p>
-                  <p class="team-name">Aryan Sharma</p>
+                  <img src="assets/Images/President.png" alt="Portrait of Aryan Sharma, President in Charge of The Cloud Network" />
+                  <div class="team-card-info">
+                    <p class="team-role">President in Charge</p>
+                    <p class="team-name">Aryan Sharma</p>
+                  </div>
                 </div>
               </article>
-              <article class="team-card">
+              <article class="team-card team-card-leader" tabindex="0">
                 <div class="team-image">
-                  <img src="member_pictures/treasurer.svg" alt="Treasurer" />
+                  <img src="assets/Images/Treasurer.png" alt="Portrait of Pratham Patil, Treasurer of The Cloud Network" />
+                  <div class="team-card-info">
+                    <p class="team-role">Treasurer</p>
+                    <p class="team-name">Pratham Patil</p>
+                  </div>
                 </div>
-                <div class="team-card-body">
-                  <p class="team-role">Treasurer</p>
-                  <p class="team-name">Pratham Patil</p>
+              </article>
+              <article class="team-card team-card-leader" tabindex="0">
+                <div class="team-image">
+                  <img src="assets/Images/Vice-President.png" alt="Portrait of Will Greenwood, Vice President of The Cloud Network" />
+                  <div class="team-card-info">
+                    <p class="team-role">Vice President</p>
+                    <p class="team-name">Will Greenwood</p>
+                  </div>
                 </div>
               </article>
             </div>
@@ -205,7 +219,7 @@
           <div class="team-group" data-animate>
             <h3 class="team-group-title">Members</h3>
             <div class="team-grid team-grid-members">
-              <article class="team-card">
+              <article class="team-card" tabindex="0">
                 <div class="team-image">
                   <img src="club_members/member-1.svg" alt="Club member placeholder 1" />
                 </div>
@@ -213,7 +227,7 @@
                   <p class="team-name">Student Name</p>
                 </div>
               </article>
-              <article class="team-card">
+              <article class="team-card" tabindex="0">
                 <div class="team-image">
                   <img src="club_members/member-2.svg" alt="Club member placeholder 2" />
                 </div>
@@ -221,7 +235,7 @@
                   <p class="team-name">Student Name</p>
                 </div>
               </article>
-              <article class="team-card">
+              <article class="team-card" tabindex="0">
                 <div class="team-image">
                   <img src="club_members/member-3.svg" alt="Club member placeholder 3" />
                 </div>
@@ -229,7 +243,7 @@
                   <p class="team-name">Student Name</p>
                 </div>
               </article>
-              <article class="team-card">
+              <article class="team-card" tabindex="0">
                 <div class="team-image">
                   <img src="club_members/member-4.svg" alt="Club member placeholder 4" />
                 </div>
@@ -237,7 +251,7 @@
                   <p class="team-name">Student Name</p>
                 </div>
               </article>
-              <article class="team-card">
+              <article class="team-card" tabindex="0">
                 <div class="team-image">
                   <img src="club_members/member-5.svg" alt="Club member placeholder 5" />
                 </div>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -593,15 +593,17 @@ footer.site-footer {
 
 .officer-list {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.75rem;
   margin: 0;
   padding: 0;
+  justify-items: center;
 }
 
 .officer-list-item {
   display: grid;
   gap: 0.35rem;
+  text-align: center;
 }
 
 .officer-list-item dt {
@@ -617,6 +619,12 @@ footer.site-footer {
   font-size: 1.35rem;
   font-weight: 600;
   color: var(--text-primary);
+}
+
+@media (min-width: 720px) {
+  .officer-list {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
 }
 
 .resources-grid {
@@ -681,7 +689,13 @@ footer.site-footer {
 }
 
 .team-grid-leadership {
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+@media (min-width: 960px) {
+  .team-grid-leadership {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
 }
 
 .team-grid-members {
@@ -698,6 +712,7 @@ footer.site-footer {
   flex-direction: column;
   position: relative;
   transition: var(--transition-base);
+  outline: none;
 }
 
 .team-card::after {
@@ -708,14 +723,55 @@ footer.site-footer {
   background: linear-gradient(150deg, rgba(56, 189, 248, 0.12), transparent 55%);
   opacity: 0;
   transition: opacity 0.35s ease;
+  z-index: 1;
 }
 
-.team-card:hover {
+.team-card-leader {
+  display: block;
+  padding: 0;
+}
+
+.team-card-leader .team-image {
+  position: relative;
+}
+
+.team-card-info {
+  position: absolute;
+  inset: 0;
+  padding: 1.8rem 1.5rem 1.6rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 0.45rem;
+  background: linear-gradient(to top, rgba(2, 6, 23, 0.92) 0%, rgba(2, 6, 23, 0.78) 38%, rgba(2, 6, 23, 0) 75%);
+  z-index: 2;
+  transition: background 0.35s cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+
+.team-card-leader:is(:hover, :focus-visible) .team-card-info {
+  background: linear-gradient(to top, rgba(2, 6, 23, 0.95) 0%, rgba(2, 6, 23, 0.82) 42%, rgba(2, 6, 23, 0.05) 78%);
+}
+
+.team-card-leader .team-role,
+.team-card-leader .team-name {
+  text-align: left;
+}
+
+.team-card-leader .team-name {
+  font-size: 1.2rem;
+}
+
+.team-card:focus-visible {
+  outline: 2px solid rgba(56, 189, 248, 0.65);
+  outline-offset: 4px;
+}
+
+.team-card:is(:hover, :focus-visible) {
   transform: translateY(-6px);
   box-shadow: 0 30px 60px -35px rgba(56, 189, 248, 0.75);
 }
 
-.team-card:hover::after {
+.team-card:is(:hover, :focus-visible)::after {
   opacity: 1;
 }
 


### PR DESCRIPTION
## Summary
- expand the officer grid to three balanced roles and add the new vice president entry
- resize the leadership cards with image fades, overlay text, and keyboard focus while introducing the vice president card
- remove the temporary treasurer and vice president portrait assets so the final images can be uploaded separately

## Testing
- no automated tests (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d205956a18832489fc0d49ef44f652