### PR TITLE
Refine leadership card gradient overlay

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -755,15 +755,17 @@ footer.site-footer {
   position: absolute;
   inset: 0;
   z-index: -1;
+  /* Premium continuous fade that keeps officer details anchored within a high-contrast zone. */
   background: linear-gradient(
-    180deg,
-    rgba(2, 6, 23, 0.93) 5%,
-    rgba(2, 6, 23, 0.86) 32%,
-    rgba(2, 6, 23, 0.55) 55%,
-    rgba(2, 6, 23, 0.08) 80%,
+    to top,
+    rgba(2, 6, 23, 0.92) 0%,
+    rgba(2, 6, 23, 0.86) 18%,
+    rgba(2, 6, 23, 0.72) 36%,
+    rgba(2, 6, 23, 0.52) 54%,
+    rgba(2, 6, 23, 0.28) 72%,
+    rgba(2, 6, 23, 0.12) 86%,
     rgba(2, 6, 23, 0) 100%
   );
-  clip-path: polygon(0 100%, 100% 100%, 100% 34%, 0 56%);
   opacity: 0.98;
   transition: opacity 0.45s cubic-bezier(0.25, 0.8, 0.25, 1);
 }


### PR DESCRIPTION
## Summary
- replace the leadership card overlay clip-path with a continuous vertical gradient fade
- maintain officer text contrast and placement inside the softened fade zone across all portraits

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d2116c98648324bdc74aa37f5a23c0