### PR TITLE
Implement bottom-only blur for Meet the Team portraits

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -851,6 +851,81 @@ footer.site-footer {
   background: radial-gradient(circle at top, rgba(56, 189, 248, 0.25), transparent 65%);
 }
 
+.team-image::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+  /* Backdrop blur is shaped with a mask so the intensity eases from strong to none. */
+  backdrop-filter: blur(clamp(18px, 4vw, 32px));
+  -webkit-backdrop-filter: blur(clamp(18px, 4vw, 32px));
+  background: linear-gradient(
+    to top,
+    rgba(2, 6, 23, 0.32) 0%,
+    rgba(2, 6, 23, 0.26) 12%,
+    rgba(2, 6, 23, 0.16) 24%,
+    rgba(2, 6, 23, 0.08) 32%,
+    rgba(2, 6, 23, 0) 44%
+  );
+  mask-image: linear-gradient(
+    to top,
+    rgba(0, 0, 0, 0.98) 0%,
+    rgba(0, 0, 0, 0.92) 8%,
+    rgba(0, 0, 0, 0.65) 18%,
+    rgba(0, 0, 0, 0.32) 30%,
+    rgba(0, 0, 0, 0.12) 36%,
+    rgba(0, 0, 0, 0) 42%
+  );
+  -webkit-mask-image: linear-gradient(
+    to top,
+    rgba(0, 0, 0, 0.98) 0%,
+    rgba(0, 0, 0, 0.92) 8%,
+    rgba(0, 0, 0, 0.65) 18%,
+    rgba(0, 0, 0, 0.32) 30%,
+    rgba(0, 0, 0, 0.12) 36%,
+    rgba(0, 0, 0, 0) 42%
+  );
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+}
+
+@media (max-width: 720px) {
+  .team-image::after {
+    mask-image: linear-gradient(
+      to top,
+      rgba(0, 0, 0, 0.96) 0%,
+      rgba(0, 0, 0, 0.88) 7%,
+      rgba(0, 0, 0, 0.58) 16%,
+      rgba(0, 0, 0, 0.26) 26%,
+      rgba(0, 0, 0, 0.1) 32%,
+      rgba(0, 0, 0, 0) 38%
+    );
+    -webkit-mask-image: linear-gradient(
+      to top,
+      rgba(0, 0, 0, 0.96) 0%,
+      rgba(0, 0, 0, 0.88) 7%,
+      rgba(0, 0, 0, 0.58) 16%,
+      rgba(0, 0, 0, 0.26) 26%,
+      rgba(0, 0, 0, 0.1) 32%,
+      rgba(0, 0, 0, 0) 38%
+    );
+  }
+}
+
+@supports not ((backdrop-filter: blur(0)) or (-webkit-backdrop-filter: blur(0))) {
+  .team-image::after {
+    background: linear-gradient(
+      to top,
+      rgba(2, 6, 23, 0.38) 0%,
+      rgba(2, 6, 23, 0.28) 12%,
+      rgba(2, 6, 23, 0.16) 24%,
+      rgba(2, 6, 23, 0.06) 34%,
+      rgba(2, 6, 23, 0) 44%
+    );
+  }
+}
+
 .team-image img {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
## Summary
- add a masked backdrop-blur overlay to team card portraits so the blur is heaviest at the bottom and eases upward
- tailor the gradient mask for mobile breakpoints to keep faces sharp while preserving the blurred base for titles
- include a graceful fallback gradient when backdrop-filter support is unavailable

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d218695fac832493aeae8ee0e8fe25