### PR TITLE
Apply tapered bottom blur to Meet the Team portraits

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -857,33 +857,36 @@ footer.site-footer {
   inset: 0;
   pointer-events: none;
   z-index: 1;
-  /* Backdrop blur is shaped with a mask so the intensity eases from strong to none. */
-  backdrop-filter: blur(clamp(18px, 4vw, 32px));
-  -webkit-backdrop-filter: blur(clamp(18px, 4vw, 32px));
+  /* Backdrop blur is shaped with a vertical mask so the strength eases from strong at the base to none by ~38%. */
+  backdrop-filter: blur(clamp(20px, 5vw, 36px));
+  -webkit-backdrop-filter: blur(clamp(20px, 5vw, 36px));
   background: linear-gradient(
     to top,
-    rgba(2, 6, 23, 0.32) 0%,
-    rgba(2, 6, 23, 0.26) 12%,
-    rgba(2, 6, 23, 0.16) 24%,
-    rgba(2, 6, 23, 0.08) 32%,
-    rgba(2, 6, 23, 0) 44%
+    rgba(2, 6, 23, 0.4) 0%,
+    rgba(2, 6, 23, 0.34) 10%,
+    rgba(2, 6, 23, 0.22) 22%,
+    rgba(2, 6, 23, 0.12) 32%,
+    rgba(2, 6, 23, 0.04) 38%,
+    rgba(2, 6, 23, 0) 42%
   );
   mask-image: linear-gradient(
     to top,
-    rgba(0, 0, 0, 0.98) 0%,
-    rgba(0, 0, 0, 0.92) 8%,
-    rgba(0, 0, 0, 0.65) 18%,
-    rgba(0, 0, 0, 0.32) 30%,
-    rgba(0, 0, 0, 0.12) 36%,
+    rgba(0, 0, 0, 1) 0%,
+    rgba(0, 0, 0, 0.95) 6%,
+    rgba(0, 0, 0, 0.78) 16%,
+    rgba(0, 0, 0, 0.52) 26%,
+    rgba(0, 0, 0, 0.24) 34%,
+    rgba(0, 0, 0, 0.08) 38%,
     rgba(0, 0, 0, 0) 42%
   );
   -webkit-mask-image: linear-gradient(
     to top,
-    rgba(0, 0, 0, 0.98) 0%,
-    rgba(0, 0, 0, 0.92) 8%,
-    rgba(0, 0, 0, 0.65) 18%,
-    rgba(0, 0, 0, 0.32) 30%,
-    rgba(0, 0, 0, 0.12) 36%,
+    rgba(0, 0, 0, 1) 0%,
+    rgba(0, 0, 0, 0.95) 6%,
+    rgba(0, 0, 0, 0.78) 16%,
+    rgba(0, 0, 0, 0.52) 26%,
+    rgba(0, 0, 0, 0.24) 34%,
+    rgba(0, 0, 0, 0.08) 38%,
     rgba(0, 0, 0, 0) 42%
   );
   mask-repeat: no-repeat;
@@ -894,21 +897,48 @@ footer.site-footer {
   .team-image::after {
     mask-image: linear-gradient(
       to top,
-      rgba(0, 0, 0, 0.96) 0%,
-      rgba(0, 0, 0, 0.88) 7%,
-      rgba(0, 0, 0, 0.58) 16%,
-      rgba(0, 0, 0, 0.26) 26%,
-      rgba(0, 0, 0, 0.1) 32%,
-      rgba(0, 0, 0, 0) 38%
+      rgba(0, 0, 0, 1) 0%,
+      rgba(0, 0, 0, 0.92) 6%,
+      rgba(0, 0, 0, 0.7) 14%,
+      rgba(0, 0, 0, 0.42) 22%,
+      rgba(0, 0, 0, 0.18) 30%,
+      rgba(0, 0, 0, 0.06) 34%,
+      rgba(0, 0, 0, 0) 36%
     );
     -webkit-mask-image: linear-gradient(
       to top,
-      rgba(0, 0, 0, 0.96) 0%,
-      rgba(0, 0, 0, 0.88) 7%,
-      rgba(0, 0, 0, 0.58) 16%,
-      rgba(0, 0, 0, 0.26) 26%,
-      rgba(0, 0, 0, 0.1) 32%,
-      rgba(0, 0, 0, 0) 38%
+      rgba(0, 0, 0, 1) 0%,
+      rgba(0, 0, 0, 0.92) 6%,
+      rgba(0, 0, 0, 0.7) 14%,
+      rgba(0, 0, 0, 0.42) 22%,
+      rgba(0, 0, 0, 0.18) 30%,
+      rgba(0, 0, 0, 0.06) 34%,
+      rgba(0, 0, 0, 0) 36%
+    );
+  }
+}
+
+@media (max-width: 520px) {
+  .team-image::after {
+    mask-image: linear-gradient(
+      to top,
+      rgba(0, 0, 0, 1) 0%,
+      rgba(0, 0, 0, 0.9) 6%,
+      rgba(0, 0, 0, 0.64) 12%,
+      rgba(0, 0, 0, 0.36) 20%,
+      rgba(0, 0, 0, 0.14) 26%,
+      rgba(0, 0, 0, 0.05) 30%,
+      rgba(0, 0, 0, 0) 32%
+    );
+    -webkit-mask-image: linear-gradient(
+      to top,
+      rgba(0, 0, 0, 1) 0%,
+      rgba(0, 0, 0, 0.9) 6%,
+      rgba(0, 0, 0, 0.64) 12%,
+      rgba(0, 0, 0, 0.36) 20%,
+      rgba(0, 0, 0, 0.14) 26%,
+      rgba(0, 0, 0, 0.05) 30%,
+      rgba(0, 0, 0, 0) 32%
     );
   }
 }
@@ -917,12 +947,25 @@ footer.site-footer {
   .team-image::after {
     background: linear-gradient(
       to top,
-      rgba(2, 6, 23, 0.38) 0%,
-      rgba(2, 6, 23, 0.28) 12%,
-      rgba(2, 6, 23, 0.16) 24%,
-      rgba(2, 6, 23, 0.06) 34%,
-      rgba(2, 6, 23, 0) 44%
+      rgba(2, 6, 23, 0.46) 0%,
+      rgba(2, 6, 23, 0.34) 14%,
+      rgba(2, 6, 23, 0.18) 26%,
+      rgba(2, 6, 23, 0.08) 34%,
+      rgba(2, 6, 23, 0) 40%
     );
+  }
+
+  @media (max-width: 520px) {
+    .team-image::after {
+      background: linear-gradient(
+        to top,
+        rgba(2, 6, 23, 0.42) 0%,
+        rgba(2, 6, 23, 0.3) 12%,
+        rgba(2, 6, 23, 0.16) 22%,
+        rgba(2, 6, 23, 0.06) 30%,
+        rgba(2, 6, 23, 0) 32%
+      );
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- reshape the officer portrait overlay to use a vertical mask that concentrates blur at the base and clears by ~40% height
- tune responsive mask stops for tablet and mobile breakpoints so the fade clears faces while keeping titles legible
- adjust the non-backdrop-filter fallback gradient to mirror the refined coverage on smaller screens

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d21a98d23083248d2fc7815ca9dae1