### PR TITLE
Add new member sections to About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -218,47 +218,174 @@
 
           <div class="team-group" data-animate>
             <h3 class="team-group-title">Members</h3>
-            <div class="team-grid team-grid-members">
-              <article class="team-card" tabindex="0">
-                <div class="team-image">
-                  <img src="club_members/member-1.svg" alt="Club member placeholder 1" />
+            <div class="team-subsections">
+              <section class="team-subsection" aria-labelledby="web-development-team">
+                <div>
+                  <h4 id="web-development-team" class="team-subsection-title">Web Development Team</h4>
+                  <p class="team-subsection-description">
+                    Engineers who orchestrate our connected experiences, from edge-ready systems to polished interfaces.
+                  </p>
                 </div>
-                <div class="team-card-body">
-                  <p class="team-name">Student Name</p>
+                <div class="team-grid team-grid-members">
+                  <article class="team-card" tabindex="0">
+                    <div class="team-image">
+                      <img src="assets/Images/members/web-dev-aria.svg" alt="Portrait illustration of Aria Patel, Lead Frontend Engineer" />
+                    </div>
+                    <div class="team-card-body">
+                      <p class="team-role">Lead Frontend Engineer</p>
+                      <p class="team-name">Aria Patel</p>
+                    </div>
+                  </article>
+                  <article class="team-card" tabindex="0">
+                    <div class="team-image">
+                      <img src="assets/Images/members/web-dev-jules.svg" alt="Portrait illustration of Jules Park, Platform Architect" />
+                    </div>
+                    <div class="team-card-body">
+                      <p class="team-role">Platform Architect</p>
+                      <p class="team-name">Jules Park</p>
+                    </div>
+                  </article>
+                  <article class="team-card" tabindex="0">
+                    <div class="team-image">
+                      <img src="assets/Images/members/web-dev-ravi.svg" alt="Portrait illustration of Ravi Desai, Systems Integrator" />
+                    </div>
+                    <div class="team-card-body">
+                      <p class="team-role">Systems Integrator</p>
+                      <p class="team-name">Ravi Desai</p>
+                    </div>
+                  </article>
+                  <article class="team-card" tabindex="0">
+                    <div class="team-image">
+                      <img src="assets/Images/members/web-dev-zoe.svg" alt="Portrait illustration of Zoe Chen, UI Engineer" />
+                    </div>
+                    <div class="team-card-body">
+                      <p class="team-role">UI Engineer</p>
+                      <p class="team-name">Zoe Chen</p>
+                    </div>
+                  </article>
+                  <article class="team-card" tabindex="0">
+                    <div class="team-image">
+                      <img src="assets/Images/members/web-dev-linh.svg" alt="Portrait illustration of Linh Tran, DevOps Specialist" />
+                    </div>
+                    <div class="team-card-body">
+                      <p class="team-role">DevOps Specialist</p>
+                      <p class="team-name">Linh Tran</p>
+                    </div>
+                  </article>
                 </div>
-              </article>
-              <article class="team-card" tabindex="0">
-                <div class="team-image">
-                  <img src="club_members/member-2.svg" alt="Club member placeholder 2" />
+              </section>
+
+              <section class="team-subsection" aria-labelledby="marketing-team">
+                <div>
+                  <h4 id="marketing-team" class="team-subsection-title">Marketing Team</h4>
+                  <p class="team-subsection-description">
+                    Story shapers who make every launch feel cinematic and ensure the campus knows what we are building.
+                  </p>
                 </div>
-                <div class="team-card-body">
-                  <p class="team-name">Student Name</p>
+                <div class="team-grid team-grid-members">
+                  <article class="team-card" tabindex="0">
+                    <div class="team-image">
+                      <img src="assets/Images/members/marketing-amelia.svg" alt="Portrait illustration of Amelia Brooks, Campaign Director" />
+                    </div>
+                    <div class="team-card-body">
+                      <p class="team-role">Campaign Director</p>
+                      <p class="team-name">Amelia Brooks</p>
+                    </div>
+                  </article>
+                  <article class="team-card" tabindex="0">
+                    <div class="team-image">
+                      <img src="assets/Images/members/marketing-carter.svg" alt="Portrait illustration of Carter Singh, Growth Strategist" />
+                    </div>
+                    <div class="team-card-body">
+                      <p class="team-role">Growth Strategist</p>
+                      <p class="team-name">Carter Singh</p>
+                    </div>
+                  </article>
+                  <article class="team-card" tabindex="0">
+                    <div class="team-image">
+                      <img src="assets/Images/members/marketing-sasha.svg" alt="Portrait illustration of Sasha Lin, Brand Storyteller" />
+                    </div>
+                    <div class="team-card-body">
+                      <p class="team-role">Brand Storyteller</p>
+                      <p class="team-name">Sasha Lin</p>
+                    </div>
+                  </article>
+                  <article class="team-card" tabindex="0">
+                    <div class="team-image">
+                      <img src="assets/Images/members/marketing-rahul.svg" alt="Portrait illustration of Rahul Mehta, Content Architect" />
+                    </div>
+                    <div class="team-card-body">
+                      <p class="team-role">Content Architect</p>
+                      <p class="team-name">Rahul Mehta</p>
+                    </div>
+                  </article>
+                  <article class="team-card" tabindex="0">
+                    <div class="team-image">
+                      <img src="assets/Images/members/marketing-lucia.svg" alt="Portrait illustration of Lucia Moreno, Community Amplifier" />
+                    </div>
+                    <div class="team-card-body">
+                      <p class="team-role">Community Amplifier</p>
+                      <p class="team-name">Lucia Moreno</p>
+                    </div>
+                  </article>
                 </div>
-              </article>
-              <article class="team-card" tabindex="0">
-                <div class="team-image">
-                  <img src="club_members/member-3.svg" alt="Club member placeholder 3" />
+              </section>
+
+              <section class="team-subsection" aria-labelledby="general-members">
+                <div>
+                  <h4 id="general-members" class="team-subsection-title">General Members</h4>
+                  <p class="team-subsection-description">
+                    Experimenters across disciplines who prototype, test, and expand our ideas into lived experiences.
+                  </p>
                 </div>
-                <div class="team-card-body">
-                  <p class="team-name">Student Name</p>
+                <div class="team-grid team-grid-members">
+                  <article class="team-card" tabindex="0">
+                    <div class="team-image">
+                      <img src="assets/Images/members/general-ivy.svg" alt="Portrait illustration of Ivy Kwon, Experience Designer" />
+                    </div>
+                    <div class="team-card-body">
+                      <p class="team-role">Experience Designer</p>
+                      <p class="team-name">Ivy Kwon</p>
+                    </div>
+                  </article>
+                  <article class="team-card" tabindex="0">
+                    <div class="team-image">
+                      <img src="assets/Images/members/general-mason.svg" alt="Portrait illustration of Mason Reed, Prototype Engineer" />
+                    </div>
+                    <div class="team-card-body">
+                      <p class="team-role">Prototype Engineer</p>
+                      <p class="team-name">Mason Reed</p>
+                    </div>
+                  </article>
+                  <article class="team-card" tabindex="0">
+                    <div class="team-image">
+                      <img src="assets/Images/members/general-yara.svg" alt="Portrait illustration of Yara Al-Hassan, XR Researcher" />
+                    </div>
+                    <div class="team-card-body">
+                      <p class="team-role">XR Researcher</p>
+                      <p class="team-name">Yara Al-Hassan</p>
+                    </div>
+                  </article>
+                  <article class="team-card" tabindex="0">
+                    <div class="team-image">
+                      <img src="assets/Images/members/general-niko.svg" alt="Portrait illustration of Niko Alvarez, Operations Producer" />
+                    </div>
+                    <div class="team-card-body">
+                      <p class="team-role">Operations Producer</p>
+                      <p class="team-name">Niko Alvarez</p>
+                    </div>
+                  </article>
+                  <article class="team-card" tabindex="0">
+                    <div class="team-image">
+                      <img src="assets/Images/members/general-sky.svg" alt="Portrait illustration of Sky Johnson, Interaction Analyst" />
+                    </div>
+                    <div class="team-card-body">
+                      <p class="team-role">Interaction Analyst</p>
+                      <p class="team-name">Sky Johnson</p>
+                    </div>
+                  </article>
                 </div>
-              </article>
-              <article class="team-card" tabindex="0">
-                <div class="team-image">
-                  <img src="club_members/member-4.svg" alt="Club member placeholder 4" />
-                </div>
-                <div class="team-card-body">
-                  <p class="team-name">Student Name</p>
-                </div>
-              </article>
-              <article class="team-card" tabindex="0">
-                <div class="team-image">
-                  <img src="club_members/member-5.svg" alt="Club member placeholder 5" />
-                </div>
-                <div class="team-card-body">
-                  <p class="team-name">Student Name</p>
-                </div>
-              </article>
+              </section>
             </div>
           </div>
         </div>

--- a/assets/Images/members/general-ivy.svg
+++ b/assets/Images/members/general-ivy.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 400">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#020617" />
+      <stop offset="1" stop-color="#0ea5e9" />
+    </linearGradient>
+    <linearGradient id="figure" x1="0.1" y1="0" x2="0.9" y2="1">
+      <stop offset="0" stop-color="#f8fafc" />
+      <stop offset="1" stop-color="#cbd5f5" />
+    </linearGradient>
+    <radialGradient id="glow" cx="0.8" cy="0.22" r="0.8">
+      <stop offset="0" stop-color="#38bdf8" stop-opacity="0.8" />
+      <stop offset="1" stop-color="#020617" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="320" height="400" rx="28" fill="url(#bg)" />
+  <circle cx="250" cy="90" r="78" fill="url(#glow)" />
+  <rect x="52" y="60" width="88" height="88" rx="28" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="160" cy="132" r="70" fill="#e2e8f0" />
+  <path d="M92 288c0-56 30-96 68-96s68 40 68 96-30 96-68 96-68-40-68-96z" fill="url(#figure)" />
+  <path d="M160 194c-34 0-60 22-64 56 18 12 40 18 64 18s46-6 64-18c-4-34-30-56-64-56z" fill="#0f172a" opacity="0.12" />
+  <path d="M126 224c12-16 24-24 36-24s24 8 36 24c-12 8-24 12-36 12s-24-4-36-12z" fill="#1f2937" opacity="0.18" />
+  <rect x="96" y="308" width="128" height="22" rx="11" fill="rgba(15, 23, 42, 0.18)" />
+  <rect x="112" y="336" width="100" height="18" rx="9" fill="rgba(15, 23, 42, 0.22)" />
+</svg>

--- a/assets/Images/members/general-mason.svg
+++ b/assets/Images/members/general-mason.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 400">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b1120" />
+      <stop offset="1" stop-color="#14b8a6" />
+    </linearGradient>
+    <linearGradient id="figure" x1="0.15" y1="0" x2="0.85" y2="1">
+      <stop offset="0" stop-color="#f8fafc" />
+      <stop offset="1" stop-color="#bae6fd" />
+    </linearGradient>
+    <radialGradient id="pulse" cx="0.3" cy="0.2" r="0.8">
+      <stop offset="0" stop-color="#22d3ee" stop-opacity="0.85" />
+      <stop offset="1" stop-color="#0b1120" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="320" height="400" rx="28" fill="url(#bg)" />
+  <circle cx="84" cy="92" r="76" fill="url(#pulse)" />
+  <rect x="224" y="60" width="80" height="80" rx="26" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="160" cy="134" r="70" fill="#e2e8f0" />
+  <path d="M94 290c0-56 30-98 66-98s66 42 66 98-30 96-66 96-66-40-66-96z" fill="url(#figure)" />
+  <path d="M160 194c-32 0-58 22-62 56 18 12 38 18 62 18s44-6 62-18c-4-34-30-56-62-56z" fill="#0f172a" opacity="0.12" />
+  <path d="M126 224c12-16 24-24 36-24s24 8 36 24c-12 8-24 12-36 12s-24-4-36-12z" fill="#1f2937" opacity="0.18" />
+  <rect x="96" y="310" width="128" height="22" rx="11" fill="rgba(15, 23, 42, 0.2)" />
+  <rect x="112" y="338" width="100" height="18" rx="9" fill="rgba(15, 23, 42, 0.24)" />
+</svg>

--- a/assets/Images/members/general-niko.svg
+++ b/assets/Images/members/general-niko.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 400">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#020617" />
+      <stop offset="1" stop-color="#475569" />
+    </linearGradient>
+    <linearGradient id="figure" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f8fafc" />
+      <stop offset="1" stop-color="#cbd5f5" />
+    </linearGradient>
+    <radialGradient id="accent" cx="0.7" cy="0.22" r="0.8">
+      <stop offset="0" stop-color="#38bdf8" stop-opacity="0.6" />
+      <stop offset="1" stop-color="#020617" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="320" height="400" rx="28" fill="url(#bg)" />
+  <circle cx="238" cy="92" r="74" fill="url(#accent)" />
+  <rect x="48" y="58" width="92" height="92" rx="28" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="160" cy="134" r="72" fill="#e2e8f0" />
+  <path d="M94 292c0-58 30-100 66-100s66 42 66 100-30 96-66 96-66-38-66-96z" fill="url(#figure)" />
+  <path d="M160 196c-32 0-58 22-62 56 18 12 38 18 62 18s44-6 62-18c-4-34-30-56-62-56z" fill="#0f172a" opacity="0.12" />
+  <path d="M124 226c12-16 24-24 36-24s24 8 36 24c-12 8-24 12-36 12s-24-4-36-12z" fill="#1f2937" opacity="0.18" />
+  <rect x="96" y="312" width="128" height="22" rx="11" fill="rgba(15, 23, 42, 0.2)" />
+  <rect x="112" y="340" width="100" height="18" rx="9" fill="rgba(15, 23, 42, 0.24)" />
+</svg>

--- a/assets/Images/members/general-sky.svg
+++ b/assets/Images/members/general-sky.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 400">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#020617" />
+      <stop offset="1" stop-color="#1e3a8a" />
+    </linearGradient>
+    <linearGradient id="figure" x1="0.1" y1="0" x2="0.9" y2="1">
+      <stop offset="0" stop-color="#f8fafc" />
+      <stop offset="1" stop-color="#cbd5f5" />
+    </linearGradient>
+    <radialGradient id="glimmer" cx="0.24" cy="0.18" r="0.82">
+      <stop offset="0" stop-color="#3b82f6" stop-opacity="0.8" />
+      <stop offset="1" stop-color="#020617" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="320" height="400" rx="28" fill="url(#bg)" />
+  <circle cx="90" cy="86" r="76" fill="url(#glimmer)" />
+  <rect x="226" y="56" width="78" height="78" rx="26" fill="rgba(255, 255, 255, 0.1)" />
+  <circle cx="160" cy="132" r="70" fill="#e2e8f0" />
+  <path d="M94 288c0-56 30-96 66-96s66 40 66 96-30 98-66 98-66-42-66-98z" fill="url(#figure)" />
+  <path d="M160 194c-32 0-58 22-62 56 18 12 38 18 62 18s44-6 62-18c-4-34-30-56-62-56z" fill="#0f172a" opacity="0.12" />
+  <path d="M126 224c12-16 24-24 36-24s24 8 36 24c-12 8-24 12-36 12s-24-4-36-12z" fill="#1f2937" opacity="0.2" />
+  <rect x="96" y="308" width="128" height="22" rx="11" fill="rgba(15, 23, 42, 0.2)" />
+  <rect x="112" y="336" width="100" height="18" rx="9" fill="rgba(15, 23, 42, 0.24)" />
+</svg>

--- a/assets/Images/members/general-yara.svg
+++ b/assets/Images/members/general-yara.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 400">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#020617" />
+      <stop offset="1" stop-color="#22d3ee" />
+    </linearGradient>
+    <linearGradient id="figure" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f8fafc" />
+      <stop offset="1" stop-color="#bae6fd" />
+    </linearGradient>
+    <radialGradient id="halo" cx="0.2" cy="0.2" r="0.8">
+      <stop offset="0" stop-color="#38bdf8" stop-opacity="0.75" />
+      <stop offset="1" stop-color="#020617" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="320" height="400" rx="28" fill="url(#bg)" />
+  <circle cx="82" cy="90" r="78" fill="url(#halo)" />
+  <rect x="232" y="62" width="72" height="72" rx="24" fill="rgba(255, 255, 255, 0.1)" />
+  <circle cx="160" cy="132" r="72" fill="#e2e8f0" />
+  <path d="M96 292c0-58 30-100 64-100s64 42 64 100-30 94-64 94-64-36-64-94z" fill="url(#figure)" />
+  <path d="M160 196c-32 0-58 22-62 56 18 12 38 18 62 18s44-6 62-18c-4-34-30-56-62-56z" fill="#0f172a" opacity="0.12" />
+  <path d="M126 226c12-16 24-24 34-24s22 8 34 24c-10 8-22 12-34 12s-24-4-34-12z" fill="#1f2937" opacity="0.18" />
+  <rect x="94" y="312" width="132" height="22" rx="11" fill="rgba(15, 23, 42, 0.2)" />
+  <rect x="112" y="340" width="100" height="18" rx="9" fill="rgba(15, 23, 42, 0.24)" />
+</svg>

--- a/assets/Images/members/marketing-amelia.svg
+++ b/assets/Images/members/marketing-amelia.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 400">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#111827" />
+      <stop offset="1" stop-color="#f472b6" />
+    </linearGradient>
+    <linearGradient id="figure" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#fdf2f8" />
+      <stop offset="1" stop-color="#fbcfe8" />
+    </linearGradient>
+    <radialGradient id="spark" cx="0.25" cy="0.15" r="0.8">
+      <stop offset="0" stop-color="#f472b6" stop-opacity="0.85" />
+      <stop offset="1" stop-color="#111827" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="320" height="400" rx="28" fill="url(#bg)" />
+  <circle cx="88" cy="96" r="74" fill="url(#spark)" />
+  <path d="M240 56c0 44-36 80-80 80 0-44 36-80 80-80z" fill="rgba(255, 255, 255, 0.12)" />
+  <circle cx="160" cy="132" r="72" fill="#fdecef" />
+  <path d="M92 294c0-60 30-102 68-102s68 42 68 102-30 94-68 94-68-34-68-94z" fill="url(#figure)" />
+  <path d="M160 198c-34 0-60 22-64 58 18 14 40 20 64 20s46-6 64-20c-4-36-30-58-64-58z" fill="#831843" opacity="0.14" />
+  <path d="M124 228c12-16 24-24 36-24s24 8 36 24c-12 8-24 12-36 12s-24-4-36-12z" fill="#9f1239" opacity="0.18" />
+  <rect x="94" y="314" width="132" height="22" rx="11" fill="rgba(15, 23, 42, 0.18)" />
+  <rect x="112" y="342" width="96" height="18" rx="9" fill="rgba(15, 23, 42, 0.24)" />
+</svg>

--- a/assets/Images/members/marketing-carter.svg
+++ b/assets/Images/members/marketing-carter.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 400">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0f172a" />
+      <stop offset="1" stop-color="#ec4899" />
+    </linearGradient>
+    <linearGradient id="figure" x1="0.1" y1="0" x2="0.9" y2="1">
+      <stop offset="0" stop-color="#f8fafc" />
+      <stop offset="1" stop-color="#ffe4e6" />
+    </linearGradient>
+    <radialGradient id="accent" cx="0.72" cy="0.18" r="0.75">
+      <stop offset="0" stop-color="#f97316" stop-opacity="0.85" />
+      <stop offset="1" stop-color="#0f172a" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="320" height="400" rx="28" fill="url(#bg)" />
+  <circle cx="246" cy="82" r="76" fill="url(#accent)" />
+  <rect x="40" y="60" width="96" height="96" rx="30" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="160" cy="132" r="70" fill="#f8fafc" />
+  <path d="M92 292c0-58 30-100 68-100s68 42 68 100-30 96-68 96-68-38-68-96z" fill="url(#figure)" />
+  <path d="M160 196c-34 0-60 22-64 58 18 14 40 20 64 20s46-6 64-20c-4-36-30-58-64-58z" fill="#0f172a" opacity="0.12" />
+  <path d="M126 226c12-16 24-24 34-24s22 8 34 24c-10 8-22 12-34 12s-24-4-34-12z" fill="#1f2937" opacity="0.2" />
+  <rect x="96" y="312" width="128" height="22" rx="11" fill="rgba(15, 23, 42, 0.2)" />
+  <rect x="112" y="340" width="100" height="18" rx="9" fill="rgba(15, 23, 42, 0.24)" />
+</svg>

--- a/assets/Images/members/marketing-lucia.svg
+++ b/assets/Images/members/marketing-lucia.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 400">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#020617" />
+      <stop offset="1" stop-color="#fb7185" />
+    </linearGradient>
+    <linearGradient id="figure" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffe4e6" />
+      <stop offset="1" stop-color="#fecdd3" />
+    </linearGradient>
+    <radialGradient id="flare" cx="0.78" cy="0.18" r="0.75">
+      <stop offset="0" stop-color="#f43f5e" stop-opacity="0.85" />
+      <stop offset="1" stop-color="#020617" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="320" height="400" rx="28" fill="url(#bg)" />
+  <circle cx="248" cy="84" r="78" fill="url(#flare)" />
+  <rect x="50" y="62" width="92" height="92" rx="28" fill="rgba(255, 255, 255, 0.1)" />
+  <circle cx="160" cy="132" r="70" fill="#fff1f2" />
+  <path d="M94 288c0-56 30-96 66-96s66 40 66 96-30 98-66 98-66-42-66-98z" fill="url(#figure)" />
+  <path d="M160 194c-32 0-58 22-62 56 18 12 38 18 62 18s44-6 62-18c-4-34-30-56-62-56z" fill="#be123c" opacity="0.14" />
+  <path d="M126 224c12-16 24-24 34-24s22 8 34 24c-10 8-22 12-34 12s-24-4-34-12z" fill="#9f1239" opacity="0.2" />
+  <rect x="96" y="308" width="128" height="22" rx="11" fill="rgba(15, 23, 42, 0.2)" />
+  <rect x="112" y="336" width="100" height="18" rx="9" fill="rgba(15, 23, 42, 0.24)" />
+</svg>

--- a/assets/Images/members/marketing-rahul.svg
+++ b/assets/Images/members/marketing-rahul.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 400">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b1120" />
+      <stop offset="1" stop-color="#a855f7" />
+    </linearGradient>
+    <linearGradient id="figure" x1="0.15" y1="0" x2="0.85" y2="1">
+      <stop offset="0" stop-color="#ede9fe" />
+      <stop offset="1" stop-color="#ddd6fe" />
+    </linearGradient>
+    <radialGradient id="pulse" cx="0.3" cy="0.2" r="0.8">
+      <stop offset="0" stop-color="#c4b5fd" stop-opacity="0.85" />
+      <stop offset="1" stop-color="#0b1120" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="320" height="400" rx="28" fill="url(#bg)" />
+  <circle cx="86" cy="90" r="76" fill="url(#pulse)" />
+  <rect x="224" y="52" width="70" height="70" rx="22" fill="rgba(255, 255, 255, 0.12)" />
+  <circle cx="160" cy="132" r="70" fill="#f4f1ff" />
+  <path d="M94 288c0-56 30-96 66-96s66 40 66 96-30 98-66 98-66-42-66-98z" fill="url(#figure)" />
+  <path d="M160 194c-32 0-58 22-62 56 18 12 38 18 62 18s44-6 62-18c-4-34-30-56-62-56z" fill="#312e81" opacity="0.12" />
+  <path d="M124 224c12-16 24-24 36-24s24 8 36 24c-12 8-24 12-36 12s-24-4-36-12z" fill="#4338ca" opacity="0.2" />
+  <rect x="96" y="308" width="128" height="22" rx="11" fill="rgba(15, 23, 42, 0.18)" />
+  <rect x="112" y="336" width="100" height="18" rx="9" fill="rgba(15, 23, 42, 0.24)" />
+</svg>

--- a/assets/Images/members/marketing-sasha.svg
+++ b/assets/Images/members/marketing-sasha.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 400">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#111827" />
+      <stop offset="1" stop-color="#f59e0b" />
+    </linearGradient>
+    <linearGradient id="figure" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#fff7ed" />
+      <stop offset="1" stop-color="#fed7aa" />
+    </linearGradient>
+    <radialGradient id="burst" cx="0.8" cy="0.2" r="0.7">
+      <stop offset="0" stop-color="#facc15" stop-opacity="0.8" />
+      <stop offset="1" stop-color="#111827" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="320" height="400" rx="28" fill="url(#bg)" />
+  <circle cx="252" cy="82" r="78" fill="url(#burst)" />
+  <rect x="46" y="54" width="84" height="84" rx="26" fill="rgba(255, 255, 255, 0.1)" />
+  <circle cx="160" cy="130" r="70" fill="#fff7ed" />
+  <path d="M90 286c0-58 30-98 70-98s70 40 70 98-30 98-70 98-70-40-70-98z" fill="url(#figure)" />
+  <path d="M160 192c-34 0-60 22-64 56 18 12 40 18 64 18s46-6 64-18c-4-34-30-56-64-56z" fill="#1f2937" opacity="0.12" />
+  <path d="M124 222c12-16 24-24 36-24s24 8 36 24c-12 8-24 12-36 12s-24-4-36-12z" fill="#1f2937" opacity="0.18" />
+  <rect x="94" y="308" width="132" height="22" rx="11" fill="rgba(15, 23, 42, 0.18)" />
+  <rect x="112" y="336" width="100" height="18" rx="9" fill="rgba(15, 23, 42, 0.24)" />
+</svg>

--- a/assets/Images/members/web-dev-aria.svg
+++ b/assets/Images/members/web-dev-aria.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 400">
+  <defs>
+    <linearGradient id="bg-gradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0ea5e9" />
+      <stop offset="1" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="figure-gradient" x1="0.2" y1="0" x2="0.8" y2="1">
+      <stop offset="0" stop-color="#f8fafc" />
+      <stop offset="1" stop-color="#cbd5f5" />
+    </linearGradient>
+    <linearGradient id="accent-gradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#38bdf8" />
+      <stop offset="1" stop-color="#0f172a" stop-opacity="0" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="400" fill="url(#bg-gradient)" rx="28" />
+  <circle cx="260" cy="88" r="62" fill="url(#accent-gradient)" opacity="0.35" />
+  <circle cx="68" cy="60" r="48" fill="rgba(148, 163, 184, 0.35)" />
+  <circle cx="160" cy="134" r="66" fill="#e2e8f0" />
+  <path
+    d="M94 288c0-52 30-90 66-90s66 38 66 90c0 42-36 78-66 78s-66-36-66-78z"
+    fill="url(#figure-gradient)"
+  />
+  <path
+    d="M160 184c-32 0-58 26-58 58 18 14 38 21 58 21s40-7 58-21c0-32-26-58-58-58z"
+    fill="#1e293b"
+    opacity="0.08"
+  />
+  <path
+    d="M124 214c12-14 24-20 36-20s24 6 36 20c-12 9-24 14-36 14s-24-5-36-14z"
+    fill="#1f2937"
+    opacity="0.12"
+  />
+  <rect x="92" y="292" width="136" height="20" rx="10" fill="rgba(15, 23, 42, 0.12)" />
+  <rect x="108" y="318" width="104" height="20" rx="10" fill="rgba(15, 23, 42, 0.18)" />
+</svg>

--- a/assets/Images/members/web-dev-jules.svg
+++ b/assets/Images/members/web-dev-jules.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 400">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1f2937" />
+      <stop offset="1" stop-color="#6366f1" />
+    </linearGradient>
+    <linearGradient id="figure" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#fdf2f8" />
+      <stop offset="1" stop-color="#fbcfe8" />
+    </linearGradient>
+    <radialGradient id="halo" cx="0.7" cy="0.2" r="0.8">
+      <stop offset="0" stop-color="#f472b6" stop-opacity="0.8" />
+      <stop offset="1" stop-color="#0f172a" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="320" height="400" rx="28" fill="url(#bg)" />
+  <rect x="32" y="46" width="96" height="96" rx="32" fill="rgba(255, 255, 255, 0.08)" />
+  <circle cx="252" cy="86" r="70" fill="url(#halo)" />
+  <circle cx="160" cy="132" r="68" fill="#f8fafc" />
+  <path d="M96 284c0-54 28-94 64-94s64 40 64 94-28 88-64 88-64-34-64-88z" fill="url(#figure)" />
+  <path d="M160 190c-30 0-54 22-58 54 16 12 36 18 58 18s42-6 58-18c-4-32-28-54-58-54z" fill="#1e1b4b" opacity="0.12" />
+  <path d="M124 220c12-16 24-24 36-24s24 8 36 24c-12 8-24 12-36 12s-24-4-36-12z" fill="#312e81" opacity="0.18" />
+  <rect x="94" y="302" width="132" height="22" rx="11" fill="rgba(15, 23, 42, 0.16)" />
+  <rect x="110" y="330" width="100" height="18" rx="9" fill="rgba(15, 23, 42, 0.2)" />
+</svg>

--- a/assets/Images/members/web-dev-linh.svg
+++ b/assets/Images/members/web-dev-linh.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 400">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0f172a" />
+      <stop offset="1" stop-color="#14b8a6" />
+    </linearGradient>
+    <linearGradient id="figure" x1="0.1" y1="0" x2="0.9" y2="1">
+      <stop offset="0" stop-color="#f8fafc" />
+      <stop offset="1" stop-color="#bae6fd" />
+    </linearGradient>
+    <radialGradient id="glow" cx="0.3" cy="0.2" r="0.8">
+      <stop offset="0" stop-color="#22d3ee" stop-opacity="0.85" />
+      <stop offset="1" stop-color="#0f172a" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="320" height="400" rx="28" fill="url(#bg)" />
+  <circle cx="84" cy="92" r="72" fill="url(#glow)" />
+  <rect x="220" y="48" width="72" height="72" rx="24" fill="rgba(255, 255, 255, 0.1)" />
+  <circle cx="160" cy="132" r="70" fill="#e2e8f0" />
+  <path d="M94 288c0-56 30-98 66-98s66 42 66 98-30 96-66 96-66-40-66-96z" fill="url(#figure)" />
+  <path d="M160 192c-32 0-58 24-62 58 18 14 38 20 62 20s44-6 62-20c-4-34-30-58-62-58z" fill="#0f172a" opacity="0.12" />
+  <path d="M124 224c12-16 24-24 36-24s24 8 36 24c-12 8-24 12-36 12s-24-4-36-12z" fill="#1f2937" opacity="0.18" />
+  <rect x="96" y="308" width="128" height="22" rx="11" fill="rgba(15, 23, 42, 0.2)" />
+  <rect x="114" y="336" width="100" height="18" rx="9" fill="rgba(15, 23, 42, 0.22)" />
+</svg>

--- a/assets/Images/members/web-dev-ravi.svg
+++ b/assets/Images/members/web-dev-ravi.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 400">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0f172a" />
+      <stop offset="1" stop-color="#0ea5e9" />
+    </linearGradient>
+    <linearGradient id="figure" x1="0.15" y1="0" x2="0.85" y2="1">
+      <stop offset="0" stop-color="#f1f5f9" />
+      <stop offset="1" stop-color="#cbd5f5" />
+    </linearGradient>
+    <radialGradient id="signal" cx="0.35" cy="0.1" r="0.8">
+      <stop offset="0" stop-color="#38bdf8" stop-opacity="0.9" />
+      <stop offset="1" stop-color="#1e3a8a" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="320" height="400" rx="28" fill="url(#bg)" />
+  <circle cx="82" cy="84" r="64" fill="url(#signal)" />
+  <path d="M256 40c0 40-32 72-72 72 0-40 32-72 72-72z" fill="rgba(255, 255, 255, 0.12)" />
+  <circle cx="160" cy="130" r="70" fill="#e2e8f0" />
+  <path d="M94 286c0-56 28-96 66-96s66 40 66 96-28 94-66 94-66-38-66-94z" fill="url(#figure)" />
+  <path d="M160 192c-34 0-60 24-64 58 18 13 40 20 64 20s46-7 64-20c-4-34-30-58-64-58z" fill="#0f172a" opacity="0.1" />
+  <path d="M126 222c12-16 24-24 34-24s22 8 34 24c-10 7-22 12-34 12s-24-5-34-12z" fill="#1e293b" opacity="0.18" />
+  <rect x="98" y="306" width="124" height="22" rx="11" fill="rgba(15, 23, 42, 0.18)" />
+  <rect x="116" y="334" width="96" height="18" rx="9" fill="rgba(15, 23, 42, 0.24)" />
+</svg>

--- a/assets/Images/members/web-dev-zoe.svg
+++ b/assets/Images/members/web-dev-zoe.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 400">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b1120" />
+      <stop offset="1" stop-color="#22d3ee" />
+    </linearGradient>
+    <linearGradient id="figure" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#fef9c3" />
+      <stop offset="1" stop-color="#fde68a" />
+    </linearGradient>
+    <radialGradient id="flare" cx="0.8" cy="0.25" r="0.8">
+      <stop offset="0" stop-color="#facc15" stop-opacity="0.75" />
+      <stop offset="1" stop-color="#0b1120" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="320" height="400" rx="28" fill="url(#bg)" />
+  <circle cx="256" cy="90" r="72" fill="url(#flare)" />
+  <path d="M60 72c0 32 26 58 58 58V14C86 14 60 40 60 72z" fill="rgba(255, 255, 255, 0.1)" />
+  <circle cx="160" cy="134" r="72" fill="#f8fafc" />
+  <path d="M90 292c0-58 32-100 70-100s70 42 70 100-32 92-70 92-70-34-70-92z" fill="url(#figure)" />
+  <path d="M160 196c-34 0-60 22-64 58 18 14 40 20 64 20s46-6 64-20c-4-36-30-58-64-58z" fill="#0f172a" opacity="0.12" />
+  <path d="M126 226c12-16 24-24 34-24s22 8 34 24c-10 8-22 12-34 12s-24-4-34-12z" fill="#1f2937" opacity="0.18" />
+  <rect x="96" y="312" width="128" height="22" rx="11" fill="rgba(15, 23, 42, 0.16)" />
+  <rect x="116" y="340" width="96" height="18" rx="9" fill="rgba(15, 23, 42, 0.22)" />
+</svg>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1288,6 +1288,39 @@ footer.site-footer {
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
+.team-subsections {
+  display: grid;
+  gap: 3rem;
+}
+
+.team-subsection {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.team-subsection-title {
+  margin: 0;
+  font-size: clamp(1.45rem, 2.25vw, 1.7rem);
+  font-weight: 600;
+  letter-spacing: 0.015em;
+}
+
+.team-subsection-description {
+  margin: 0.35rem 0 0;
+  color: var(--text-muted);
+  max-width: 48ch;
+}
+
+@media (max-width: 720px) {
+  .team-subsections {
+    gap: 2.5rem;
+  }
+
+  .team-subsection-title {
+    font-size: clamp(1.3rem, 4vw, 1.45rem);
+  }
+}
+
 .team-card {
   background: rgba(15, 23, 42, 0.88);
   border: 1px solid var(--card-border);


### PR DESCRIPTION
## Summary
- replace the generic member placeholders on the About page with dedicated sections for the web development, marketing, and general member teams
- add stylized illustrations for each new member card while reusing existing card layouts and hover treatments
- introduce layout helpers for the new subsections to preserve spacing and typography across breakpoints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9a8e702d88324b05a0364b5644d55