### PR TITLE
Update About page web development team roster

### DIFF
--- a/about.html
+++ b/about.html
@@ -229,47 +229,38 @@
                 <div class="team-grid team-grid-members">
                   <article class="team-card" tabindex="0">
                     <div class="team-image">
-                      <img src="assets/Images/members/web-dev-aria.svg" alt="Portrait illustration of Aria Patel, Lead Frontend Engineer" />
+                      <img src="assets/Images/members/web-dev-aria.svg" alt="Portrait illustration representing Will Greenwood, Lead Frontend Engineer" />
                     </div>
                     <div class="team-card-body">
                       <p class="team-role">Lead Frontend Engineer</p>
-                      <p class="team-name">Aria Patel</p>
+                      <p class="team-name">Will Greenwood</p>
                     </div>
                   </article>
                   <article class="team-card" tabindex="0">
                     <div class="team-image">
-                      <img src="assets/Images/members/web-dev-jules.svg" alt="Portrait illustration of Jules Park, Platform Architect" />
+                      <img src="assets/Images/members/web-dev-jules.svg" alt="Portrait illustration representing Aryan Sharma, Platform Architect" />
                     </div>
                     <div class="team-card-body">
                       <p class="team-role">Platform Architect</p>
-                      <p class="team-name">Jules Park</p>
+                      <p class="team-name">Aryan Sharma</p>
                     </div>
                   </article>
                   <article class="team-card" tabindex="0">
                     <div class="team-image">
-                      <img src="assets/Images/members/web-dev-ravi.svg" alt="Portrait illustration of Ravi Desai, Systems Integrator" />
-                    </div>
-                    <div class="team-card-body">
-                      <p class="team-role">Systems Integrator</p>
-                      <p class="team-name">Ravi Desai</p>
-                    </div>
-                  </article>
-                  <article class="team-card" tabindex="0">
-                    <div class="team-image">
-                      <img src="assets/Images/members/web-dev-zoe.svg" alt="Portrait illustration of Zoe Chen, UI Engineer" />
+                      <img src="assets/Images/members/web-dev-zoe.svg" alt="Portrait illustration representing Sahil Jain, UI Engineer" />
                     </div>
                     <div class="team-card-body">
                       <p class="team-role">UI Engineer</p>
-                      <p class="team-name">Zoe Chen</p>
+                      <p class="team-name">Sahil Jain</p>
                     </div>
                   </article>
                   <article class="team-card" tabindex="0">
                     <div class="team-image">
-                      <img src="assets/Images/members/web-dev-linh.svg" alt="Portrait illustration of Linh Tran, DevOps Specialist" />
+                      <img src="assets/Images/members/web-dev-linh.svg" alt="Portrait illustration representing Shoyo Ko, DevOps Specialist" />
                     </div>
                     <div class="team-card-body">
                       <p class="team-role">DevOps Specialist</p>
-                      <p class="team-name">Linh Tran</p>
+                      <p class="team-name">Shoyo Ko</p>
                     </div>
                   </article>
                 </div>


### PR DESCRIPTION
## Summary
- update the Web Development Team cards on the About page with the new member roles and names
- remove the Systems Integrator entry so the grid reflects the current four-person roster
- refresh image alt text to describe the updated roles for accessibility compliance

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d9ac34250883249c9440ef80522f50