### PR TITLE
Adjust vice president leadership card layout

### DIFF
--- a/about.html
+++ b/about.html
@@ -204,7 +204,7 @@
                   </div>
                 </div>
               </article>
-              <article class="team-card team-card-leader" tabindex="0">
+              <article class="team-card team-card-leader team-card-leader--vice" tabindex="0">
                 <div class="team-image" style="--portrait: url('/assets/Images/WillGreenwood.svg');">
                   <img src="assets/Images/WillGreenwood.png" alt="Portrait of Will Greenwood, Vice President of The Cloud Network" />
                   <div class="team-card-info">

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1516,6 +1516,24 @@ footer.site-footer {
   transition: opacity 0.42s cubic-bezier(0.25, 0.8, 0.25, 1);
 }
 
+.team-card-leader.team-card-leader--vice .team-image img {
+  object-position: 56% center;
+  transform: scale(1.12);
+}
+
+.team-card-leader.team-card-leader--vice .team-image::before {
+  background-position: 56% bottom;
+  transform: translateY(4%) scale(1.2);
+}
+
+.team-card-leader.team-card-leader--vice:is(:hover, :focus-visible) .team-image img {
+  transform: translateY(-6px) scale(1.18);
+}
+
+.team-card-leader.team-card-leader--vice:is(:hover, :focus-visible) .team-image::before {
+  transform: translateY(1%) scale(1.26);
+}
+
 .team-card-leader:is(:hover, :focus-visible) .team-image::before {
   opacity: 0.98;
   transform: translateY(3%) scale(1.18);
@@ -1545,12 +1563,20 @@ footer.site-footer {
     bottom: -26%;
     transform: translateY(8%) scale(1.16);
   }
+
+  .team-card-leader.team-card-leader--vice .team-image::before {
+    transform: translateY(6%) scale(1.24);
+  }
 }
 
 @media (max-width: 520px) {
   .team-card-leader .team-image::before {
     top: 62%;
     bottom: -30%;
+  }
+
+  .team-card-leader.team-card-leader--vice .team-image::before {
+    transform: translateY(8%) scale(1.28);
   }
 =======
   transition: transform 0.45s cubic-bezier(0.25, 0.8, 0.25, 1);


### PR DESCRIPTION
## Summary
- center Will Greenwood's leadership portrait and give the card a dedicated modifier class
- scale the vice president imagery and overlays across breakpoints so it matches the president card's balance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9c5426fc08324b7c57a19e7722220